### PR TITLE
add wazuh to CI, fix arm64 namespace, defer cache prune

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -53,6 +53,7 @@ jobs:
             ["scadalts"]="scadalts/"
             ["attacker"]="attacker/"
             ["caldera"]="caldera/"
+            ["wazuh"]="wazuh/"
           )
 
           # rebuild everything on release
@@ -113,10 +114,10 @@ jobs:
               --provenance=true \
               --sbom=true \
               "./${SERVICE}"
-            echo "🧹 Cleaning local build cache to free space..."
-            docker builder prune -af || true
-            docker system prune -af || true
           done
+          echo "🧹 Cleaning local build cache to free space..."
+          docker builder prune -af || true
+          docker system prune -af || true
 
   # ================================================================
   # Build ARM64 images
@@ -144,7 +145,7 @@ jobs:
               echo "⚠️ Skipping ${SERVICE}: directory does not exist"
               continue
             fi
-            IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/grfics-${SERVICE}"
+            IMAGE="${DOCKERHUB_NAMESPACE}/grfics-${SERVICE}"
             echo "🚀 Building ${IMAGE}:${DOCKER_TAG} (arm64)"
             docker buildx build \
               --platform linux/arm64 \
@@ -155,10 +156,10 @@ jobs:
               --provenance=true \
               --sbom=true \
               "./${SERVICE}"
-            echo "🧹 Cleaning local build cache to free space..."
-            docker builder prune -af || true
-            docker system prune -af || true
           done
+          echo "🧹 Cleaning local build cache to free space..."
+          docker builder prune -af || true
+          docker system prune -af || true
 
   # ================================================================
   # Combine manifests once both architectures exist


### PR DESCRIPTION
- Add wazuh/ to the service map so it builds and pushes like other images
- Fix build-arm64 to use DOCKERHUB_NAMESPACE env var instead of secrets.DOCKERHUB_USERNAME, matching amd64 and manifest jobs
- Move docker builder/system prune to after the service loop so shared base layers can be reused across services within a job run