### PR TITLE
feat: add clear log buttons for firewall, IDS, DNS, and ARP logs

### DIFF
--- a/router/app.py
+++ b/router/app.py
@@ -51,6 +51,7 @@ DEFAULT_USERS = [{"username": "admin", "password_hash": generate_password_hash("
 users = [u.copy() for u in DEFAULT_USERS]
 
 LOG_FILE = "/var/log/ulog/netfilter_log.json"
+SURICATA_EVE_FILE = "/var/log/suricata/eve.json"
 FIREWALL_RULES_PATH = "/etc/firewall/rules"
 CONFIG_PATH = "/etc/firewall/config.json"
 IDS_ALERTS_FILE = "/etc/suricata/alerts.json"
@@ -93,7 +94,7 @@ def parse_firewall_logs(limit=100):
     return entries
 
 def get_recent_alerts(limit=50):
-    eve_path = Path("/var/log/suricata/eve.json")
+    eve_path = Path(SURICATA_EVE_FILE)
     alerts = []
     if not eve_path.exists():
         return alerts
@@ -1143,6 +1144,75 @@ def arp():
         devices=devices,
         events=events[-100:],
     )
+
+
+# --- log clearing routes ---
+
+def _truncate_log(path):
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        open(path, 'w').close()
+        return True
+    except OSError:
+        return False
+
+
+@app.route("/firewall/logs/clear", methods=["POST"])
+@login_required
+@admin_required
+def clear_firewall_logs():
+    if _truncate_log(LOG_FILE):
+        flash("Firewall logs cleared.", "success")
+    else:
+        flash("Failed to clear firewall logs.", "danger")
+    return redirect(url_for("firewall_logs"))
+
+
+@app.route("/ids/clear_alerts", methods=["POST"])
+@login_required
+@admin_required
+def clear_ids_alerts():
+    if _truncate_log(SURICATA_EVE_FILE):
+        flash("IDS alerts cleared.", "success")
+    else:
+        flash("Failed to clear IDS alerts.", "danger")
+    return redirect(url_for("ids"))
+
+
+@app.route("/dns/clear_queries", methods=["POST"])
+@login_required
+@admin_required
+def clear_dns_queries():
+    if _truncate_log(DNSMASQ_LOG):
+        flash("DNS query log cleared.", "success")
+    else:
+        flash("Failed to clear DNS query log.", "danger")
+    return redirect(url_for("dns"))
+
+
+@app.route("/arp/clear_events", methods=["POST"])
+@login_required
+@admin_required
+def clear_arp_events():
+    if _truncate_log(ARPMON_LOG):
+        flash("ARP events cleared.", "success")
+    else:
+        flash("Failed to clear ARP events.", "danger")
+    return redirect(url_for("arp"))
+
+
+@app.route("/arp/clear_devices", methods=["POST"])
+@login_required
+@admin_required
+def clear_arp_devices():
+    try:
+        os.makedirs(os.path.dirname(ARPMON_STATE), exist_ok=True)
+        with open(ARPMON_STATE, 'w') as f:
+            json.dump({}, f)
+        flash("Known devices reset.", "success")
+    except OSError:
+        flash("Failed to reset known devices.", "danger")
+    return redirect(url_for("arp"))
 
 
 # --- settings / user management routes ---

--- a/router/arp.html
+++ b/router/arp.html
@@ -10,7 +10,13 @@
 </div>
 
 <div class="card mb-4">
-  <div class="card-header">Known Devices</div>
+  <div class="card-header d-flex justify-content-between align-items-center">
+    Known Devices
+    <form method="post" action="{{ url_for('clear_arp_devices') }}"
+          onsubmit="return confirm('Reset known devices? ARP monitor will rediscover them from scratch.')">
+      <button type="submit" class="btn btn-sm btn-outline-warning">Reset Devices</button>
+    </form>
+  </div>
   <div class="card-body p-0">
     {% if devices %}
     <table class="table table-sm table-striped mb-0">
@@ -36,7 +42,13 @@
 </div>
 
 <div class="card">
-  <div class="card-header">ARP Events</div>
+  <div class="card-header d-flex justify-content-between align-items-center">
+    ARP Events
+    <form method="post" action="{{ url_for('clear_arp_events') }}"
+          onsubmit="return confirm('Clear all ARP events? This cannot be undone.')">
+      <button type="submit" class="btn btn-sm btn-outline-danger">Clear Events</button>
+    </form>
+  </div>
   <div class="card-body p-0">
     {% if events %}
     <table class="table table-sm mb-0">

--- a/router/dns.html
+++ b/router/dns.html
@@ -93,6 +93,10 @@
           <input class="form-check-input" type="checkbox" id="autorefresh" checked>
           <label class="form-check-label small" for="autorefresh">Auto (5s)</label>
         </div>
+        <form method="post" action="{{ url_for('clear_dns_queries') }}"
+              onsubmit="return confirm('Clear all DNS query logs? This cannot be undone.')">
+          <button type="submit" class="btn btn-sm btn-outline-danger">Clear Log</button>
+        </form>
       </div>
     </div>
 

--- a/router/firewall_logs.html
+++ b/router/firewall_logs.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Firewall Logs</h2>
+<div class="d-flex justify-content-between align-items-center mb-3">
+  <h2 class="mb-0">Firewall Logs</h2>
+  <form method="post" action="{{ url_for('clear_firewall_logs') }}"
+        onsubmit="return confirm('Clear all firewall logs? This cannot be undone.')">
+    <button type="submit" class="btn btn-sm btn-outline-danger">Clear Logs</button>
+  </form>
+</div>
 
 <table class="table table-sm table-striped align-middle">
   <thead>

--- a/router/ids.html
+++ b/router/ids.html
@@ -60,7 +60,13 @@
 </div>
 
 <div class="card">
-  <div class="card-header">Recent Alerts</div>
+  <div class="card-header d-flex justify-content-between align-items-center">
+    Recent Alerts
+    <form method="post" action="{{ url_for('clear_ids_alerts') }}"
+          onsubmit="return confirm('Clear all IDS alerts? This cannot be undone.')">
+      <button type="submit" class="btn btn-sm btn-outline-danger">Clear Alerts</button>
+    </form>
+  </div>
   <div class="card-body">
     {% if alerts %}
       <table class="table table-sm table-striped">


### PR DESCRIPTION
Adds admin-only POST routes and corresponding UI buttons to truncate each accumulating log file: netfilter firewall logs, Suricata IDS alerts, dnsmasq query log, ARP events, and ARP device state.