### PR TITLE
fix: guard getent pipe against pipefail exit when docker GID has no g…

### DIFF
--- a/simulation/entrypoint.sh
+++ b/simulation/entrypoint.sh
@@ -27,7 +27,7 @@ if [ -S /var/run/docker.sock ]; then
     # A group with this GID may already exist (e.g. 'docker' on a fresh Ubuntu install).
     # If so, reuse it rather than trying to create 'dockersock', which would fail and
     # leave no group for the subsequent usermod call.
-    DOCKER_GROUP=$(getent group "$DOCKER_GID" | cut -d: -f1)
+    DOCKER_GROUP=$(getent group "$DOCKER_GID" | cut -d: -f1 || true)
     if [ -z "$DOCKER_GROUP" ]; then
         groupadd -g "$DOCKER_GID" dockersock
         DOCKER_GROUP=dockersock


### PR DESCRIPTION
…roup

With set -euo pipefail, getent returning exit 2 (GID not found) caused the entire variable assignment to fail and the script to exit silently — the exact case the dockersock group logic was meant to handle. Adding || true inside the subshell lets set -e see a zero exit while still leaving DOCKER_GROUP empty for the downstream if [ -z ] check.