### PR TITLE
ci: skip SBOM/provenance attestation for the attacker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -183,14 +183,25 @@ jobs:
             fi
             IMAGE="${DOCKERHUB_NAMESPACE}/grfics-${SERVICE}"
             echo "🚀 Building ${IMAGE}:${DOCKER_TAG} (amd64)"
+
+            ATTEST_FLAGS="--provenance=true --sbom=true"
+            if [ "$SERVICE" = "attacker" ]; then
+              # kali + kali-tools-top10 + burpsuite pulls in thousands of
+              # packages; the generated SBOM exceeds BuildKit's attestation
+              # blob size limit (~40MiB) and fails image export. Skip
+              # attestations for this one image until upstream raises/removes
+              # that limit: https://github.com/moby/buildkit/issues/2773
+              echo "ℹ️ Skipping SBOM/provenance for ${SERVICE}: image is too large for BuildKit's attestation size limit"
+              ATTEST_FLAGS=""
+            fi
+
             docker buildx build \
               --platform linux/amd64 \
               --tag "${IMAGE}:${DOCKER_TAG}-amd64" \
               --push \
               --cache-from type=gha \
               --cache-to type=gha,mode=max \
-              --provenance=true \
-              --sbom=true \
+              $ATTEST_FLAGS \
               --build-arg "BUILD_VERSION=${{ steps.meta.outputs.version }}" \
               --build-arg "BUILD_CREATED=${{ steps.meta.outputs.created }}" \
               "./${SERVICE}"
@@ -235,14 +246,25 @@ jobs:
             fi
             IMAGE="${DOCKERHUB_NAMESPACE}/grfics-${SERVICE}"
             echo "🚀 Building ${IMAGE}:${DOCKER_TAG} (arm64)"
+
+            ATTEST_FLAGS="--provenance=true --sbom=true"
+            if [ "$SERVICE" = "attacker" ]; then
+              # kali + kali-tools-top10 + burpsuite pulls in thousands of
+              # packages; the generated SBOM exceeds BuildKit's attestation
+              # blob size limit (~40MiB) and fails image export. Skip
+              # attestations for this one image until upstream raises/removes
+              # that limit: https://github.com/moby/buildkit/issues/2773
+              echo "ℹ️ Skipping SBOM/provenance for ${SERVICE}: image is too large for BuildKit's attestation size limit"
+              ATTEST_FLAGS=""
+            fi
+
             docker buildx build \
               --platform linux/arm64 \
               --tag "${IMAGE}:${DOCKER_TAG}-arm64" \
               --push \
               --cache-from type=gha \
               --cache-to type=gha,mode=max \
-              --provenance=true \
-              --sbom=true \
+              $ATTEST_FLAGS \
               --build-arg "BUILD_VERSION=${{ steps.meta.outputs.version }}" \
               --build-arg "BUILD_CREATED=${{ steps.meta.outputs.created }}" \
               "./${SERVICE}"


### PR DESCRIPTION
The kali-based attacker image installs kali-tools-top10, burpsuite, and a JRE - thousands of packages - and the resulting SBOM exceeds BuildKit's attestation blob size limit (~40MiB), failing the image export entirely:

  ERROR: /tmp/buildkit-mount.../sbom.spdx.json exceeds 41943040 bytes

This is a known BuildKit limitation with large images (moby/buildkit#2773, moby/buildkit#5327), not something introduced by this branch - it surfaced now because this branch's workflow-file change tripped the existing "shared files changed -> rebuild everything" fallback, which hadn't included the attacker image in a build in a while. Scoped the fix to just that one service rather than disabling attestations globally, since SBOM/provenance/cosign signing is otherwise working fine for every other image.