### PR TITLE
fix: point plc's bullseye apt sources at the archive mirror

### DIFF
--- a/plc/Dockerfile
+++ b/plc/Dockerfile
@@ -9,6 +9,13 @@ WORKDIR /workdir
 
 RUN find . -type f -name "*.sh" -exec chmod +x {} \;
 
+# bullseye is EOL: deb.debian.org no longer serves a valid (non-expired)
+# bullseye-security Release file. Point at the archive mirror instead, which
+# freezes EOL releases with stable metadata; archive.debian.org doesn't
+# publish security updates for archived releases at all, so drop that line
+# rather than point it somewhere that will also go stale.
+RUN sed -i 's|deb.debian.org|archive.debian.org|g; /security/d' /etc/apt/sources.list
+
 # 1. Install dependencies (runs once, cached unless package list changes)
 
 RUN apt-get update && apt-get install -y \
@@ -17,9 +24,9 @@ RUN apt-get update && apt-get install -y \
       && find utils/ -type f -exec dos2unix {} \; \
       && cd utils/matiec_src && rm -f config/missing \
       && autoreconf --install --force --verbose \
-      && rm -rf /var/lib/apt/lists/* \
+      && rm -rf /var/lib/apt/lists/*
 
-RUN  ./install.sh docker
+RUN ./install.sh docker
 
 # 2. Copy static configs and scripts that rarely change
 COPY webserver/dnp3.cfg /workdir/webserver/dnp3_default.cfg


### PR DESCRIPTION
debian:bullseye-20240722's default sources.list points at deb.debian.org, which no longer serves a valid (non-expired) bullseye-security Release file - bullseye is EOL and that repo isn't being refreshed anymore. Switch to archive.debian.org, which freezes EOL releases with stable metadata, and drop the security line entirely since archive.debian.org doesn't publish security updates for archived releases at all.

While here, fixed a real (previously masked) bug this exposed: a stray trailing backslash after `rm -rf /var/lib/apt/lists/*` was merging the next `RUN ./install.sh docker` into the same shell command as literal text, so it never actually ran as its own build step. This was invisible before because a cached successful apt-get layer meant that RUN instruction never had to re-execute - it only became visible once the apt fix forced a fresh build of that layer.

Verified locally: built both the intermediate `base` stage and the full multi-stage image end to end. The base-stage-only build showed "Compilation finished with errors!" from install.sh, which is expected
- it runs before the ladder-logic program files are COPY'd in during the later openplc-custom stage. The real image (full build) completes with "Compilation finished successfully!" and exports cleanly.